### PR TITLE
Created Context Provider for Modal States

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 /.pnp
 .pnp.js
 
+# firebase dependencies
+functions/node_modules 
+
 # testing
 /coverage
 

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -21,17 +21,7 @@ const Routes = () => {
   return (
     <Switch>
       <Layout>
-        <Route
-          exact
-          path={''}
-          render={() => (
-            <Home
-              handleOpenSignUp={() => {
-                console.log('lol');
-              }}
-            />
-          )}
-        />
+        <Route exact path={''} render={() => <Home />} />
       </Layout>
     </Switch>
   );

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -13,8 +13,8 @@ import { auth } from 'services/firebase';
 import { ModalContext } from 'context/ModalProvider';
 
 import Button from 'components/MuiOverrides/Button/Button';
-import SignIn from 'components/SignIn/SignIn';
-import SignUp from 'components/SignUp/SignUp';
+import SignInModal from 'components/SignIn/SignIn';
+import SignUpModal from 'components/SignUp/SignUp';
 
 const useStyles = makeStyles(() =>
   createStyles({
@@ -30,8 +30,8 @@ const Layout: React.FC<{
   const classes = useStyles();
   const { signInModal, signUpModal } = React.useContext(ModalContext);
 
-  const [isSignInModalOpen, setIsSignInModalOpen] = signInModal;
-  const [isSignUpModalOpen, setIsSignUpModalOpen] = signUpModal;
+  const [, setIsSignInModalOpen] = signInModal;
+  const [, setIsSignUpModalOpen] = signUpModal;
 
   const [user] = useAuthState(auth);
 
@@ -65,22 +65,8 @@ const Layout: React.FC<{
           )}
         </Toolbar>
       </AppBar>
-      <SignIn
-        isOpen={isSignInModalOpen}
-        handleSignInClose={() => setIsSignInModalOpen(false)}
-        handleOpenSignUp={() => {
-          setIsSignInModalOpen(false);
-          setIsSignUpModalOpen(true);
-        }}
-      />
-      <SignUp
-        isOpen={isSignUpModalOpen}
-        handleSignUpClose={() => setIsSignUpModalOpen(false)}
-        handleOpenSignIn={() => {
-          setIsSignUpModalOpen(false);
-          setIsSignInModalOpen(true);
-        }}
-      />
+      <SignInModal />
+      <SignUpModal />
       {children}
     </>
   );

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import {
   AppBar,
   createStyles,
@@ -5,13 +6,15 @@ import {
   Toolbar,
   Typography,
 } from '@material-ui/core';
-import Button from 'components/MuiOverrides/Button/Button';
-import SignIn from 'components/SignIn/SignIn';
-import SignUp from 'components/SignUp/SignUp';
-import React from 'react';
 import { useAuthState } from 'react-firebase-hooks/auth';
 import { logout } from 'services/auth';
 import { auth } from 'services/firebase';
+
+import { ModalContext } from 'context/ModalProvider';
+
+import Button from 'components/MuiOverrides/Button/Button';
+import SignIn from 'components/SignIn/SignIn';
+import SignUp from 'components/SignUp/SignUp';
 
 const useStyles = makeStyles(() =>
   createStyles({
@@ -25,8 +28,10 @@ const Layout: React.FC<{
   children: React.ReactNode;
 }> = ({ children }) => {
   const classes = useStyles();
-  const [isSignInModalOpen, setIsSignInModalOpen] = React.useState(false);
-  const [isSignUpModalOpen, setIsSignUpModalOpen] = React.useState(false);
+  const { signInModal, signUpModal } = React.useContext(ModalContext);
+
+  const [isSignInModalOpen, setIsSignInModalOpen] = signInModal;
+  const [isSignUpModalOpen, setIsSignUpModalOpen] = signUpModal;
 
   const [user] = useAuthState(auth);
 

--- a/src/components/SignIn/SignIn.tsx
+++ b/src/components/SignIn/SignIn.tsx
@@ -1,17 +1,30 @@
+import React from 'react';
 import { Dialog, DialogTitle, DialogContent } from '@material-ui/core';
+
+import { ModalContext } from 'context/ModalProvider';
+import { login, socialSignIn } from 'services/auth';
+
 import Button from 'components/MuiOverrides/Button/Button';
 import Link from 'components/MuiOverrides/Link/Link';
 import TextField from 'components/TextField/TextField';
-import React from 'react';
-import { login, socialSignIn } from 'services/auth';
 
-const SignIn: React.FC<{
-  isOpen: boolean;
-  handleSignInClose: () => void;
-  handleOpenSignUp: () => void;
-}> = ({ isOpen, handleSignInClose, handleOpenSignUp }) => {
+const SignIn: React.FC = () => {
+  const { signInModal, signUpModal } = React.useContext(ModalContext);
+
   const [email, setEmail] = React.useState('');
   const [password, setPassword] = React.useState('');
+
+  const [signInModalOpen, setSignInModalOpen] = signInModal;
+  const [, setSignUpModalOpen] = signUpModal;
+
+  const handleOpenSignUp = () => {
+    setSignInModalOpen(false);
+    setSignUpModalOpen(true);
+  };
+
+  const handleSignInClose = () => {
+    setSignInModalOpen(false);
+  };
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -24,6 +37,7 @@ const SignIn: React.FC<{
     console.log('logged in');
     handleSignInClose();
   };
+
   const handleSocialSignIn = async (socialNetwork: 'facebook' | 'google') => {
     const result = await socialSignIn(socialNetwork);
 
@@ -37,7 +51,7 @@ const SignIn: React.FC<{
 
   return (
     <Dialog
-      open={isOpen}
+      open={signInModalOpen}
       fullWidth={true}
       maxWidth="lg"
       onClose={handleSignInClose}

--- a/src/components/SignUp/SignUp.tsx
+++ b/src/components/SignUp/SignUp.tsx
@@ -1,17 +1,30 @@
-import { Dialog, DialogTitle, DialogContent } from '@material-ui/core';
-import Button from 'components/MuiOverrides/Button/Button';
-import TextField from 'components/TextField/TextField';
 import React from 'react';
+import { Dialog, DialogTitle, DialogContent } from '@material-ui/core';
+
+import { ModalContext } from 'context/ModalProvider';
 import { register, socialSignIn } from 'services/auth';
 
-const SignUp: React.FC<{
-  isOpen: boolean;
-  handleSignUpClose: () => void;
-  handleOpenSignIn: () => void;
-}> = ({ isOpen, handleSignUpClose, handleOpenSignIn }) => {
+import Button from 'components/MuiOverrides/Button/Button';
+import TextField from 'components/TextField/TextField';
+
+const SignUp: React.FC = () => {
+  const { signInModal, signUpModal } = React.useContext(ModalContext);
+
   const [username, setUsername] = React.useState('');
   const [email, setEmail] = React.useState('');
   const [password, setPassword] = React.useState('');
+
+  const [, setSignInModalOpen] = signInModal;
+  const [signUpModalOpen, setSignUpModalOpen] = signUpModal;
+
+  const handleOpenSignIn = () => {
+    setSignUpModalOpen(false);
+    setSignInModalOpen(true);
+  };
+
+  const handleSignUpClose = () => {
+    setSignUpModalOpen(false);
+  };
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -38,7 +51,7 @@ const SignUp: React.FC<{
 
   return (
     <Dialog
-      open={isOpen}
+      open={signUpModalOpen}
       fullWidth={true}
       maxWidth="lg"
       onClose={handleSignUpClose}

--- a/src/context/ModalProvider.tsx
+++ b/src/context/ModalProvider.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 //@ts-ignore
 export const ModalContext = React.createContext<{
-  signInModal: [boolean, React.Dispatch<any>];
-  signUpModal: [boolean, React.Dispatch<any>];
+  signInModal: [boolean, React.Dispatch<boolean>];
+  signUpModal: [boolean, React.Dispatch<boolean>];
 }>();
 
 const ModalProvider: React.FC<{ children: React.ReactChild }> = ({

--- a/src/context/ModalProvider.tsx
+++ b/src/context/ModalProvider.tsx
@@ -1,19 +1,26 @@
 import React from 'react';
 
+//@ts-ignore
+export const ModalContext = React.createContext<{
+  signInModal: [boolean, React.Dispatch<any>];
+  signUpModal: [boolean, React.Dispatch<any>];
+}>();
+
 const ModalProvider: React.FC<{ children: React.ReactChild }> = ({
   children,
 }) => {
-  const [modalStates, setModalStates] = React.useState({
-    signInModalOpen: false,
-    signUpModalOpen: false,
-  });
-
-  const Context = React.createContext([modalStates, setModalStates]);
+  const signInModal = React.useState<boolean>(false);
+  const signUpModal = React.useState<boolean>(false);
 
   return (
-    <Context.Provider value={[modalStates, setModalStates]}>
+    <ModalContext.Provider
+      value={{
+        signInModal,
+        signUpModal,
+      }}
+    >
       {children}
-    </Context.Provider>
+    </ModalContext.Provider>
   );
 };
 

--- a/src/context/ModalProvider.tsx
+++ b/src/context/ModalProvider.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+const ModalProvider: React.FC<{ children: React.ReactChild }> = ({
+  children,
+}) => {
+  const [modalStates, setModalStates] = React.useState({
+    signInModalOpen: false,
+    signUpModalOpen: false,
+  });
+
+  const Context = React.createContext([modalStates, setModalStates]);
+
+  return (
+    <Context.Provider value={[modalStates, setModalStates]}>
+      {children}
+    </Context.Provider>
+  );
+};
+
+export default ModalProvider;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,10 +3,13 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import ModalContextProvider from './context/ModalProvider';
 
 ReactDOM.render(
   <MUI>
-    <App />
+    <ModalContextProvider>
+      <App />
+    </ModalContextProvider>
   </MUI>,
   document.getElementById('root')
 );

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -5,10 +5,9 @@ import { useDocument } from 'react-firebase-hooks/firestore';
 import { useAuthState } from 'react-firebase-hooks/auth';
 
 import Button from 'components/MuiOverrides/Button/Button';
+import { ModalContext } from 'context/ModalProvider';
 
-const Home: React.FC<{ handleOpenSignUp: () => void }> = ({
-  handleOpenSignUp,
-}) => {
+const Home: React.FC = () => {
   const [value, loading, error] = useDocument(
     db.doc('rooms/iQyRNrz8ULPE08PX37q4'),
     {
@@ -17,6 +16,10 @@ const Home: React.FC<{ handleOpenSignUp: () => void }> = ({
   );
 
   const [user] = useAuthState(firebase.auth());
+
+  const { signUpModal } = React.useContext(ModalContext);
+
+  const [, setIsSignUpModalOpen] = signUpModal;
 
   return (
     <>
@@ -28,7 +31,7 @@ const Home: React.FC<{ handleOpenSignUp: () => void }> = ({
       </p>
       <Button
         onClick={() => {
-          !user && handleOpenSignUp();
+          !user && setIsSignUpModalOpen(true);
         }}
       >
         Create a room

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -31,13 +31,6 @@ const Home: React.FC<{ handleOpenSignUp: () => void }> = ({
       >
         Create a room
       </Button>
-      {/* <button
-        onClick={() => {
-          !user && setIsLoginModalOpen(true);
-        }}
-      >
-        Create new room
-      </button> */}
     </>
   );
 };

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import firebase from 'firebase';
 import { db } from 'services/firebase';
 import { useDocument } from 'react-firebase-hooks/firestore';
 import { useAuthState } from 'react-firebase-hooks/auth';
-import firebase from 'firebase';
+
 import Button from 'components/MuiOverrides/Button/Button';
 
 const Home: React.FC<{ handleOpenSignUp: () => void }> = ({
@@ -14,6 +15,7 @@ const Home: React.FC<{ handleOpenSignUp: () => void }> = ({
       snapshotListenOptions: { includeMetadataChanges: true },
     }
   );
+
   const [user] = useAuthState(firebase.auth());
 
   return (


### PR DESCRIPTION
- Created `context/ModalProvider` to handle all Modal states
- Added `ModalContextProvider` as a wrapper to the `App`
- Setup a state for both `signInModal` and `signUpModal` in the Modal Context Provider
- Replaced existing `useState` hooks with the Context provided hooks
- Modal states can be managed via the state hooks in the context

_cleanup_
- Tidied up imports in most files touched 